### PR TITLE
deprecate bsmtrace_error

### DIFF
--- a/bsmtrace.h
+++ b/bsmtrace.h
@@ -39,13 +39,14 @@ struct g_conf {
 	char	*pflag;
 	char	*lflag;
 	int	 logfd;
+	int	 nflag;
 };
 
 struct g_conf opts;
 int	audit_pipe_fd;	/* XXX not happy about this global */
 
-void	bsmtrace_error(int, char *, ...);
-void	bsmtrace_exit(int) __attribute__ ((noreturn));
+void	bsmtrace_warn(char *, ...);
+void	bsmtrace_fatal(char *, ...) __attribute__ ((noreturn));
 void	debug_printf(char *, ...);
 void	usage(char *);
 #endif	/* BSM_TRACE_H_ */

--- a/conf.c
+++ b/conf.c
@@ -92,7 +92,7 @@ conf_load(char *path)
 
 	f = fopen(path, "r");
 	if (f == NULL)
-		bsmtrace_error(1, "%s: %s", path, strerror(errno));
+		bsmtrace_fatal("%s: %s", path, strerror(errno));
 	conffile = path;
 	yyin = f;
 	TAILQ_INIT(&bsm_set_head);
@@ -114,7 +114,7 @@ conf_detail(int ln, const char *fmt, ...)
 	va_start(ap, fmt);
 	(void) vsnprintf(buf, sizeof(buf), fmt, ap);
 	va_end(ap);
-	bsmtrace_error(1, "%s:%d: %s", conffile, ln, buf);
+	bsmtrace_fatal("%s:%d: %s", conffile, ln, buf);
 }
 
 /*
@@ -184,14 +184,14 @@ conf_array_add(const char *str, struct array *a, int type)
 	case SET_TYPE_PCRE:
 		re = pcre_compile(str, 0, &error, &erroffset, NULL);
 		if (error != 0)
-			bsmtrace_error(1, "%s: pcre_compile failed", __func__);
+			bsmtrace_fatal("%s: pcre_compile failed", __func__);
 		break;
 #endif
 	case SET_TYPE_PATH:
 	case SET_TYPE_LOGCHANNEL:
 		ptr = strdup(str);
 		if (ptr == NULL)
-			bsmtrace_error(1, "%s: strdup failed", __func__);
+			bsmtrace_fatal("%s: strdup failed", __func__);
 		break;
 	}
 	if (e != 0) {
@@ -210,7 +210,7 @@ conf_array_add(const char *str, struct array *a, int type)
 #endif
 	} else {
 		if (value == -1) {
-			bsmtrace_error(1, "%s: un-initialized 'value'\n");
+			bsmtrace_fatal("%s: un-initialized 'value'\n");
 		}
 		a->a_data.value[a->a_cnt++] = value;
 		a->a_type = INTEGER_ARRAY;
@@ -268,7 +268,7 @@ conf_handle_multiplier(struct bsm_sequence *bs, struct bsm_state *bm)
 		bm->bm_multiplier = 1;
 	vec = calloc(bm->bm_multiplier, sizeof(*bm));
 	if (vec == NULL)
-		bsmtrace_error(1, "%s: calloc failed", __func__);
+		bsmtrace_fatal("%s: calloc failed", __func__);
 	for (i = 0; i < bm->bm_multiplier; i++) {
 		dst = &vec[i];
 		assert(dst != NULL);

--- a/grammar.y
+++ b/grammar.y
@@ -75,7 +75,7 @@ define_def:
 	{
 		assert(set_state == NULL);
 		if ((set_state = calloc(1, sizeof(*set_state))) == NULL)
-			bsmtrace_error(1, "%s: calloc failed", __func__);
+			bsmtrace_fatal("%s: calloc failed", __func__);
 		if ((set_state->bss_type = conf_set_type($5)) == -1)
 			conf_detail(0, "%s: invalid set type", $5);
 		/* free() this later. */
@@ -110,7 +110,7 @@ anon_set:
 		struct bsm_set *new;
 
 		if ((new = calloc(1, sizeof(*new))) == NULL)
-			bsmtrace_error(1, "%s: calloc failed", __func__);
+			bsmtrace_fatal("%s: calloc failed", __func__);
 		if ((new->bss_type = conf_set_type($2)) == -1)
 			conf_detail(0, "%s: invalid set type", $2);
 		set_state = new;
@@ -203,7 +203,7 @@ sequence_def:
 	{
 		assert(bs_state == NULL);
 		if ((bs_state = calloc(1, sizeof(*bs_state))) == NULL)
-			bsmtrace_error(1, "%s: calloc failed", __func__);
+			bsmtrace_fatal("%s: calloc failed", __func__);
 		/* This will be a parent sequence. */
 		bs_state->bs_seq_flags |= BSM_SEQUENCE_PARENT;
 		bs_state->bs_seq_scope = BSM_SCOPE_GLOBAL;
@@ -218,7 +218,7 @@ sequence_def:
 		if (conf_get_parent_sequence($3) != NULL)
 			conf_detail(0, "%s: sequence exists", $3);
 		if ((bs_state->bs_label = strdup($3)) == NULL)
-			bsmtrace_error(1, "%s: strdup failed", __func__);
+			bsmtrace_fatal("%s: strdup failed", __func__);
 		TAILQ_INSERT_HEAD(&s_parent, bs_state, bs_glue);
 		bs_state = NULL;
 	}
@@ -426,7 +426,7 @@ state:
 	{
 		assert(bm_state == NULL);
 		if ((bm_state = calloc(1, sizeof(*bm_state))) == NULL)
-			bsmtrace_error(1, "%s: calloc failed", __func__);
+			bsmtrace_fatal("%s: calloc failed", __func__);
 	}
 	OBRACE state_options EBRACE SEMICOLON
 	{

--- a/trigger.c
+++ b/trigger.c
@@ -124,29 +124,30 @@ bsm_run_trigger(struct bsm_record_data *bd, struct bsm_state *bm)
 	cmd = bsm_expand_trigger(bd, bm);
 	if (cmd != NULL) {
 		/*
-		 * XXX should the failure to execute a trigger be a fatal?
+		 * NB: should the failure to execute a trigger be fatal?
 		 */
 		ret = fork();
 		if (ret < 0)
-			bsmtrace_error(1, "%s: fork failed", __func__);
+			bsmtrace_fatal("%s: fork failed", __func__);
 		if (ret == 0) {
 			n = 0;
 			args = calloc(1, sizeof(char *) * TRIGGER_ARGS_MAX);
 			if (args == NULL)
-				bsmtrace_error(1, "%s: calloc failed",
-				    __func__);
+				bsmtrace_fatal("%s: calloc failed", __func__);
 			debug_printf("executing trigger: '%s'\n", cmd);
 			while ((ptr = strsep(&cmd, " ")) != NULL) {
 				if (*ptr == '\0')
 					continue;
 				if ((args[n++] = strdup(ptr)) == NULL)
-					bsmtrace_error(1, "%s: strdup failed",
+					bsmtrace_fatal("%s: strdup failed",
 					    __func__);
 			}
 			(void) execve(args[0], args, NULL);
-			bsmtrace_error(1, "execve: %s", strerror(errno));
+			bsmtrace_fatal("execve: %s", strerror(errno));
 		}
 		free(cmd);
-	} else /* XXX Report expansion failure here */
-		bsmtrace_error(0, "%s: expansion failed", bm->bm_trig);
+	} else /*
+		* NB: we should Report expansion variables which failed.
+		*/
+		bsmtrace_warn("%s: expansion failed", bm->bm_trig);
 }


### PR DESCRIPTION
- Deprecate bsmtrace_error().  This function ended up confusing some
  static analyzers.  In some case it would return, and others it
  wouldn't.
- Introduce bsmtrace_warn() (non-fatal) and bsmtrace_fatal (fatal)
  and set the noreturn attribute

This reduces false positives reported by static analyzers.