### PR TITLE
Use hdr64_ex, not hdr32_ex for AUT_HEADER64_EX tokens

### DIFF
--- a/bsm.c
+++ b/bsm.c
@@ -601,7 +601,7 @@ bsm_loop(char *atrail)
 				bd.br_usec = tok.tt.hdr64.ms;
 				break;
 			case AUT_HEADER64_EX:
-				bd.br_event = tok.tt.hdr32_ex.e_type;
+				bd.br_event = tok.tt.hdr64_ex.e_type;
 				bd.br_sec = tok.tt.hdr64_ex.s;
 				bd.br_usec = tok.tt.hdr64_ex.ms;
 				break;


### PR DESCRIPTION
The `e_type` field was read from `AUT_HEADER64_EX` tokens using the `hdr32_ex` struct instead of `hdr64_ex` - this commit fixes this. The inadvertent use of `hdr32_ex` instead of `hdr64_ex` was inconsequential because the e_type field is at the same offset and has the type and size in both structs.