### PR TITLE
array: plug use-after-free

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -88,7 +88,6 @@ define_def:
 		src = $9;
 		dst = &set_state->bss_data;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		TAILQ_INSERT_TAIL(&bsm_set_head, set_state, bss_glue);
 		set_state = NULL;
@@ -124,7 +123,6 @@ anon_set:
 		src = $6;
 		dst = &set_state->bss_data;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		$$ = set_state;
 		set_state = NULL;
@@ -310,7 +308,6 @@ type_spec:
 		src = &ptr->bss_data;
 		dst = &bm_state->bm_auditevent;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		dst->a_negated = $2;
 	}
@@ -326,7 +323,6 @@ type_spec:
 		src = &$3->bss_data;
 		dst = &bm_state->bm_auditevent;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		dst->a_negated = $2;
 	}
@@ -358,7 +354,6 @@ object_spec:
 		src = &ptr->bss_data;
 		dst = &bm_state->bm_objects;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		dst->a_negated = $2;
 	}
@@ -377,7 +372,6 @@ object_spec:
 #endif
 		dst = &bm_state->bm_objects;
 		*dst = *src;
-		free(array_state.a_data);
 		bzero(&array_state, sizeof(struct array));
 		dst->a_negated = $2;
 	}


### PR DESCRIPTION
The a_data pointer gets copied into the dst struct array with *dst = *src.
Freeing src->a_data then leads to a use-after-free that trivially prevents
use of the data (e.g. event type).

This fixes the default configuration on my system (FreeBSD 13.0-CURRENT), which were reading garbage from the arrays later in bsm.c and never matching the event type.

Sponsored by:	Modirum MDPay, Klara Systems