### PR TITLE
Add a method to mark sequences for specific zones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.yy.c
+bsmtrace
+y.output
+y.tab.c
+y.tab.h

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ lex.yy.o: y.tab.h token.l
 bsmtrace: $(OBJ)
 	$(CC) $(CFLAGS) -o $@ $(OBJ) $(LIBS)
 
+.ORDER:	clean bsmtrace install
+.ORDER:	deinstall install
+
 install:
 	[ -d $(PREFIX)/bin ] || mkdir -p $(PREFIX)/bin
 	install -m 0555 bsmtrace $(PREFIX)/bin

--- a/bsm.c
+++ b/bsm.c
@@ -646,6 +646,9 @@ bsm_loop(char *atrail)
 			case AUT_PATH:
 				bd.br_path = tok.tt.path.path;
 				break;
+			case AUT_ZONENAME:
+				bd.br_zonename = tok.tt.zonename.zonename;
+				break;
 			}
 			bytesread += tok.len;
 		}

--- a/bsm.c
+++ b/bsm.c
@@ -207,6 +207,37 @@ bsm_log_sequence(struct bsm_sequence *bs, struct bsm_record_data *bd)
 		(void) write(1, bd->br_raw, bd->br_raw_len);
 }
 
+static inline bool
+bsm_dyn_subj_check(struct bsm_sequence *bs_dyn, struct bsm_record_data *bd,
+    u_int subj)
+{
+
+	/* If the subject doesn't match, we can trivially reject it. */
+	if (bs_dyn->bs_subj.bs_dyn_subj != subj)
+		return (false);
+
+	/*
+	 * If the zonename is NULL, then this is a globally applicable rule.
+	 * This and the above case are the two most likely commonly hit, so
+	 * we've organized these two first.
+	 */
+	if (bs_dyn->bs_zonename == NULL)
+		return (true);
+
+	/*
+	 * Next check for the special case of bs_zonename == NONE, where we can
+	 * proceed only if the record's zonename isn't set.  In all remaining
+	 * cases, we must have a record zonename.
+	 */
+	if (bs_dyn->bs_zonename == ZONENAME_NONE)
+		return (bd->br_zonename == NULL);
+	else if (bd->br_zonename == NULL)
+		return (false);
+
+	/* Finally, match on the zonename. */
+	return (strcmp(bs_dyn->bs_zonename, bd->br_zonename) == 0);
+}
+
 static int
 bsm_state_match(struct bsm_sequence *bs, struct bsm_record_data *bd)
 {
@@ -219,7 +250,7 @@ bsm_state_match(struct bsm_sequence *bs, struct bsm_record_data *bd)
 	 * Do we have a subject match? At this point we EXPLICITLY do not handle
 	 * negation as it should have been handled by the parent.
 	 */
-	match = (bs->bs_subj.bs_dyn_subj == bsm_get_subj(bs, bd));
+	match = bsm_dyn_subj_check(bs, bd, bsm_get_subj(bs, bd));
 	if (match == 0)
 		return (0);
 	/* Match event. */
@@ -273,12 +304,50 @@ bsm_get_subj(struct bsm_sequence *bs, struct bsm_record_data *bd)
 }
 
 static int
+bsm_check_sequence_zone(struct bsm_sequence *bs, struct bsm_record_data *bd)
+{
+
+	if (bs->bs_zonename == NULL)
+		return (1);
+
+	/*
+	 * Match zone as needed.  A NULL bs_zonename means that this sequence is
+	 * globally applicable.  If it's not NULL, it may be one of:
+	 * - NONE   (Host-only sequence)
+	 * - ANY    (Any zone sequence)
+	 * - A glob (Zones matching the glob)
+	 *
+	 * If it's a glob, it will never match the host.  One could also specify a
+	 * a glob like '*' to mean ANY, but the latter provides a decent shortcut
+	 * that doesn't require the overhead of a glob.
+	 */
+	if (bs->bs_zonename == ZONENAME_NONE) {
+		/* Matches host events only. */
+		if (bd->br_zonename != NULL)
+			return (0);
+		return (1);
+	} else if (bd->br_zonename == NULL) {
+		/* Either ANY or a glob; cannot match host events. */
+		return (0);
+	} else if (bs->bs_zonename != ZONENAME_ANY) {
+		return (fnmatch(bs->bs_zonename, bd->br_zonename,
+		    FNM_PATHNAME) == 0 ? 1 : 0);
+	}
+
+	/* bs_zonename == ZONENAME_ANY */
+	return (1);
+}
+
+static int
 bsm_check_parent_sequence(struct bsm_sequence *bs, struct bsm_record_data *bd)
 {
 	struct bsm_state *bm;
 	u_int subj, match;
 
 	assert((bs->bs_seq_flags & BSM_SEQUENCE_PARENT) != 0);
+	match = bsm_check_sequence_zone(bs, bd);
+	if (match == 0)
+		return (0);
 	subj = bsm_get_subj(bs, bd);
 	match = bsm_check_subj_array(subj, &bs->bs_subj.bs_par_subj);
 	if (match == 0 && (bs->bs_seq_flags & BSM_SEQUENCE_SUBJ_ANY) == 0)
@@ -304,7 +373,7 @@ bsm_dyn_sequence_find(struct bsm_sequence *bs, struct bsm_record_data *bd,
 	TAILQ_FOREACH(bs_dyn, &s_dynamic, bs_glue)
 		if (bs_dyn->bs_par_sequence == bs &&
 		    bs_dyn->bs_subj_type == bs->bs_subj_type &&
-		    bs_dyn->bs_subj.bs_dyn_subj == subj)
+		    bsm_dyn_subj_check(bs_dyn, bd, subj))
 			return (bs_dyn);
 	return (NULL);
 }
@@ -363,6 +432,14 @@ bsm_free_sequence(struct bsm_sequence *bs)
 	assert(bs != NULL);
 	debug_printf("%s: freeing sequence %p\n", __func__, bs);
 	assert((bs->bs_seq_flags & BSM_SEQUENCE_DYNAMIC) != 0);
+	if (bs->bs_zonename != NULL && bs->bs_zonename != ZONENAME_NONE) {
+		/*
+		 * Having matched any zone should have triggered a copy of the
+		 * name.
+		 */
+		assert(bs->bs_zonename != ZONENAME_ANY);
+		free(bs->bs_zonename);
+	}
 	bsm_free_raw_data(bs);
 	while (!TAILQ_EMPTY(&bs->bs_mhead)) {
 		bm = TAILQ_FIRST(&bs->bs_mhead);
@@ -433,6 +510,20 @@ bsm_sequence_clone(struct bsm_sequence *bs, u_int subj,
 	bs_new->bs_par_sequence = bs;
 	bs_new->bs_first_match = bd->br_sec;
 	bs_new->bs_mtime = bd->br_sec;
+	/*
+	 * We need to copy the applicable zone to bs_new if it should actually
+	 * be used.  Effectively, we'll either copy the zonename that first
+	 * matched or we'll have copied over ZONENAME_NONE to indicate that
+	 * particular constraint.
+	 */
+	if (bs->bs_zonename != NULL && bs->bs_zonename != ZONENAME_NONE) {
+		/*
+		 * If we matched a glob/any, then this should be trivially true.
+		 */
+		assert(bd->br_zonename != NULL);
+		bs_new->bs_zonename = strdup(bd->br_zonename);
+	}
+
 	bsm_copy_states(bs, bs_new);
 	/*
 	 * If we have made it this far, we can assume that we have more than

--- a/bsmtrace.conf.5
+++ b/bsmtrace.conf.5
@@ -22,7 +22,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd April 04, 2007
+.Dd February 16, 2020
 .Dt BSMTRACE.CONF 5
 .Os FreeBSD 6.2
 .Sh NAME
@@ -94,6 +94,7 @@ in BNF:
 	       ["log" (<set> | <set_name>) ";"]
 	       ["serial" <value> ";"]
 	       ["scope" <scope> ";"]
+	       ["zone" ( NONE | ANY | <string> ) ";"]
                <state> { <state> } "};"
 
 <state> ::= "state {"

--- a/conf.c
+++ b/conf.c
@@ -54,7 +54,7 @@ extern char	*yytext;
 extern int	 yyparse(void);
 bsm_set_head_t	 bsm_set_head;
 int		 lineno = 1;
-char		*conffile;
+static const char		*conffile;
 
 /*
  * Return BSM set named str, or NULL if the set was not found in the BSM set

--- a/deuce.h
+++ b/deuce.h
@@ -156,6 +156,7 @@ struct bsm_record_data {
 	int		 br_sid;	/* Session ID */
 	dev_t		 br_dev;	/* For fs objects, the device id. */
 	ino_t		 br_inode;	/* For fs objects, the inode. */
+	const char	*br_zonename;	/* Zone name */
 };
 
 #endif	/* DEUCE_H_ */

--- a/deuce.h
+++ b/deuce.h
@@ -137,7 +137,16 @@ struct bsm_sequence {
 	int				 bs_seq_serial;
 	int				 bs_seq_time_wnd;
 	int				 bs_seq_time_wnd_prob;
+	char				*bs_zonename;
 };
+
+/*
+ * Define some special types for zonename: ZONENAME_NONE and ZONENAME_ANY.
+ * These take advantage of non-printable characters to do the dirty work, which
+ * works kind of like mmap(2) in that these will never occur in the input space.
+ */
+#define	ZONENAME_NONE		((char *)1)	/* Host-only. */
+#define	ZONENAME_ANY		((char *)2)	/* Any jail, not the host. */
 
 struct bsm_record_data {
 	u_int64_t	 br_status;	/* Event exit status */

--- a/includes.h
+++ b/includes.h
@@ -40,6 +40,7 @@
 #include <sys/uio.h>
 #include <sys/un.h>
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -47,6 +48,7 @@
 #include <pwd.h>
 #include <grp.h>
 #include <fcntl.h>
+#include <fnmatch.h>
 #include <errno.h>
 #include <ctype.h>
 #include <unistd.h>

--- a/token.l
+++ b/token.l
@@ -71,6 +71,7 @@ timeout-window	return (TIMEOUTWND);
 timeout-prob	return (TIMEOUTPROB);
 trigger		return (TRIGGER);
 weeks		return (WEEKS);
+zone		return (ZONE);
 {integer}	{
 			yylval.num = atoi(yytext);
 			return (INTEGER);


### PR DESCRIPTION
This allows one of three options for zone configuration of sequences:
- none
- any
- glob expression

None will only match the host and explicitly will not match jails.

Any will match any jail, but never match the host.

The glob will be tested against zonename using the POSIX-specified fnmatch(3). Notably, this will also never match the host.

bsmtrace.conf(5) has been expanded to include the new zone option.

Sponsored by: Modirum MDPay, Klara Systems