### PR TITLE
Add 'includes' directive

### DIFF
--- a/conf.c
+++ b/conf.c
@@ -55,6 +55,7 @@ extern int	 yyparse(void);
 bsm_set_head_t	 bsm_set_head;
 int		 lineno = 1;
 static const char		*conffile;
+const char	*yyfile;
 
 /*
  * Return BSM set named str, or NULL if the set was not found in the BSM set

--- a/conf.c
+++ b/conf.c
@@ -94,7 +94,7 @@ conf_load(char *path)
 	f = fopen(path, "r");
 	if (f == NULL)
 		bsmtrace_fatal("%s: %s", path, strerror(errno));
-	conffile = path;
+	yyfile = conffile = path;
 	yyin = f;
 	TAILQ_INIT(&bsm_set_head);
 	yyparse();
@@ -115,7 +115,7 @@ conf_detail(int ln, const char *fmt, ...)
 	va_start(ap, fmt);
 	(void) vsnprintf(buf, sizeof(buf), fmt, ap);
 	va_end(ap);
-	bsmtrace_fatal("%s:%d: %s", conffile, ln, buf);
+	bsmtrace_fatal("%s:%d: %s", yyfile, ln, buf);
 }
 
 /*

--- a/conf.c
+++ b/conf.c
@@ -101,6 +101,13 @@ conf_load(char *path)
 	(void) fclose(f);
 }
 
+const char *
+conf_get_file(void)
+{
+
+	return (conffile);
+}
+
 /*
  * Configuration file error reporting, non-zero ln overrides lineno.
  */

--- a/conf.c
+++ b/conf.c
@@ -291,7 +291,7 @@ void
 yyerror(const char *str)
 {
 
-	conf_detail(0, "syntax error near '%s'", yytext);
+	conf_detail(0, "syntax error near '%s' (%s)", yytext, str);
 }
 
 int

--- a/conf.c
+++ b/conf.c
@@ -67,7 +67,9 @@ conf_get_bsm_set(char *str)
 	struct bsm_set *ptr;
 
 	TAILQ_FOREACH(ptr, &bsm_set_head, bss_glue) {
-		if (strcmp(str, ptr->bss_name) == 0)
+		if (strcmp(str, ptr->bss_name) == 0 &&
+		    (strcmp(ptr->bss_file, conffile) == 0 ||
+		    strcmp(ptr->bss_file, yyfile) == 0))
 			return (ptr);
 	}
 	return (NULL);

--- a/conf.h
+++ b/conf.h
@@ -32,6 +32,7 @@
 
 extern bsm_set_head_t	bsm_set_head;
 extern int 		lineno;
+extern const char	*yyfile;
 
 struct bsm_set		*conf_get_bsm_set(char *);
 struct bsm_sequence	*conf_get_parent_sequence(char *);

--- a/conf.h
+++ b/conf.h
@@ -44,6 +44,7 @@ void			 conf_array_add(const char *, struct array *, int);
 void			 conf_sequence_set_subj(struct bsm_sequence *,
 			     struct bsm_set *, int);
 int			 conf_set_type(char *);
+const char		*conf_get_file(void);
 void			 yyerror(const char *);
 int			 yywrap(void);
 void			 conf_set_log_channel(struct bsm_set *,

--- a/deuce.h
+++ b/deuce.h
@@ -94,6 +94,7 @@ struct bsm_set {
 	TAILQ_ENTRY(bsm_set)	 bss_glue;
 	char			*bss_name;
 	int			 bss_type;
+	const char		*bss_file;
 };
 typedef	TAILQ_HEAD(, bsm_set)	bsm_set_head_t;
 

--- a/grammar.y
+++ b/grammar.y
@@ -84,6 +84,7 @@ define_def:
 			conf_detail(0, "%s: invalid set type", $5);
 		/* free() this later. */
 		set_state->bss_name = $3;
+		set_state->bss_file = yyfile;
 	}
 	OBRACE set_list SEMICOLON EBRACE SEMICOLON
 	{

--- a/grammar.y
+++ b/grammar.y
@@ -93,7 +93,11 @@ define_def:
 		dst = &set_state->bss_data;
 		*dst = *src;
 		bzero(&array_state, sizeof(struct array));
-		TAILQ_INSERT_TAIL(&bsm_set_head, set_state, bss_glue);
+		/*
+		 * Insert to the head so that the latest set is always found
+		 * first.
+		 */
+		TAILQ_INSERT_HEAD(&bsm_set_head, set_state, bss_glue);
 		set_state = NULL;
 	}
 	;

--- a/grammar.y
+++ b/grammar.y
@@ -31,6 +31,7 @@
 #include "includes.h"
 
 extern int	yylex(void);
+extern int	include(const char *);
 
 static struct bsm_sequence	*bs_state;	/* BSM sequence state */
 static struct bsm_set		*set_state;	/* BSM set state */
@@ -50,7 +51,7 @@ static struct array		 array_state;	/* Volatile array */
 %token	STATUS MULTIPLIER OBRACE EBRACE SEMICOLON COMMA SUBJECT
 %token	STRING ANY SUCCESS FAILURE INTEGER TIMEOUT NOT HOURS MINUTES DAYS
 %token	PRIORITY WEEKS SECONDS NONE QUOTE OPBRACKET EPBRACKET LOGCHAN
-%token	DIRECTORY LOG SCOPE SERIAL TIMEOUTWND TIMEOUTPROB CONFIG ZONE
+%token	DIRECTORY LOG SCOPE SERIAL TIMEOUTWND TIMEOUTPROB CONFIG INCLUDE ZONE
 %type	<num> status_spec SUCCESS FAILURE INTEGER multiplier_spec timeout_spec
 %type	<num> serial_spec negate_spec priority_spec scope_spec timeout_wnd_spec
 %type	<num> timeout_prob_spec time_spec
@@ -68,6 +69,9 @@ root	: /* empty */
 cmd	:
 	define_def
 	| sequence_def
+	| INCLUDE STRING SEMICOLON {
+		include($2);
+	}
 	;
 
 define_def:

--- a/token.l
+++ b/token.l
@@ -26,11 +26,24 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
+#include <limits.h>
+
 #include "includes.h"
 #include "y.tab.h"
 
 #define YY_NO_UNPUT
 
+/* Modelled after config(8) on FreeBSD. */
+struct incl {
+	struct incl	*incl_prev;
+	YY_BUFFER_STATE	incl_buf;
+	const char	*incl_fname;
+	int		 incl_lineno;
+};
+
+static struct incl	*inclp;
+
+static void endinclude(void);
 %}
 
 %option nounput
@@ -48,6 +61,7 @@ directory	return (DIRECTORY);
 event		return (EVENT);
 failure		return (FAILURE);
 hours		return (HOURS);
+include		return (INCLUDE);
 log		return (LOG);
 log-channel	return (LOGCHAN);
 minutes		return (MINUTES);
@@ -84,6 +98,12 @@ zone		return (ZONE);
 \>		return (EPBRACKET);
 \;		return (SEMICOLON);
 \,		return (COMMA);
+<<EOF>>	{
+			if (inclp == NULL)
+				return (YY_NULL);
+			endinclude();
+			/* carry on */
+		}
 \"		{
 			char buf[1024], *ptr;
 			char c;
@@ -133,3 +153,82 @@ zone		return (ZONE);
 			assert(yylval.str != NULL);
 			return (STRING);
 		}
+%%
+
+int
+include(const char *fname)
+{
+	char filepath[PATH_MAX];
+	char *tslash;
+	FILE *fp;
+	struct incl *incl;
+
+	if (fname[0] == '/') {
+		if (strlcpy(filepath, fname, sizeof(filepath)) >=
+		    sizeof(filepath)) {
+			yyerror("invalid include file path");
+			return (-1);
+		}
+	} else {
+		/*
+		 * Grab it relative to the directory the config file is in.  We
+		 * have already opened the config file, so this part at least
+		 * won't truncate.
+		 */
+		(void) strlcpy(filepath, conf_get_file(), sizeof(filepath));
+		tslash = strrchr(filepath, '/');
+
+		/*
+		 * And we opened it as a file, so a trailing slash won't be the
+		 * last character.  If we didn't find a slash, we'll assume
+		 * relative to the working directory because the config is in
+		 * the working directory.
+		 */
+		if (tslash != NULL) {
+			*(tslash + 1) = '\0';
+		} else {
+			filepath[0] = '\0';
+		}
+
+		if (strlcat(filepath, fname, sizeof(filepath)) >=
+		    sizeof(filepath)) {
+			yyerror("invalid include file path");
+			return (-1);
+		}
+	}
+
+	fp = fopen(filepath, "r");
+	if (fp == NULL) {
+		yyerror("cannot open included file");
+		return (-1);
+	}
+
+	incl = malloc(sizeof(*incl));
+	assert(incl != NULL);
+	incl->incl_prev = inclp;
+	incl->incl_buf = YY_CURRENT_BUFFER;
+	incl->incl_fname = yyfile;
+	incl->incl_lineno = lineno;
+	inclp = incl;
+	yy_switch_to_buffer(yy_create_buffer(fp, YY_BUF_SIZE));
+	yyfile = fname;
+	lineno = 0;
+	return (0);
+}
+
+static void
+endinclude(void)
+{
+	struct incl *incl;
+
+	incl = inclp;
+	assert(incl != NULL);
+
+	inclp = incl->incl_prev;
+	yy_delete_buffer(YY_CURRENT_BUFFER);
+	(void)fclose(yyin);
+	yy_switch_to_buffer(incl->incl_buf);
+	yyfile = incl->incl_fname;
+	lineno = incl->incl_lineno;
+	free(incl);
+}


### PR DESCRIPTION
This allows other configuration files to be included to separate things out a bit; all definitions within an included file are isolated to that file.

open question: should the include file be specified to be a glob expression instead?

Sponsored by: Modirum MDPay, Klara Systems

