### PR TITLE
Add a set extension syntax

### DIFF
--- a/bsmtrace.conf.5
+++ b/bsmtrace.conf.5
@@ -22,7 +22,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd February 16, 2020
+.Dd February 22, 2020
 .Dt BSMTRACE.CONF 5
 .Os FreeBSD 6.2
 .Sh NAME
@@ -57,7 +57,9 @@ in BNF:
 <set_name> ::= "$" <alphanumeric_sequence>
 <set_type> ::= "<" ("auid" | "euid" | "ruid" | "egid" | "rgid" | "auditevent" |
                "auditclass" | "path" | "logchannel") ">"
-<set> ::= "{" (<subject_set> | <event_set> | <object_set> | <log_set>) ";}"
+<set> ::= "{" <set_spec> ";}"
+<set_spec> ::= "set" <set_name> { "," <set_spec> } |
+				(<subject_set> | <event_set> | <object_set> | <log_set>)
 
 <subject_set> ::= <auid_set> | <euid_set> | <ruid_set> | <egid_set> | <rgid_set>
 <auid_set> ::= <auid> { "," <auid> }

--- a/conf.c
+++ b/conf.c
@@ -118,6 +118,33 @@ conf_detail(int ln, const char *fmt, ...)
 	bsmtrace_fatal("%s:%d: %s", conffile, ln, buf);
 }
 
+void
+conf_merge_bsm_set(struct array *desta, struct bsm_set *src)
+{
+	struct array *srca;
+	size_t i, needed;
+
+	srca = &src->bss_data;
+	needed = desta->a_cnt + srca->a_cnt;
+	if (needed >= desta->a_size) {
+		union array_data *tmp;
+		while (needed >= desta->a_size) {
+			desta->a_size += BSM_ARRAY_MAX;
+		}
+
+		tmp = realloc(desta->a_data, desta->a_size);
+		if (tmp == NULL) {
+			err(1, "Failed to allocate memory");
+		}
+		desta->a_data = tmp;
+	}
+
+	for (i = 0; i < srca->a_cnt; i++) {
+		desta->a_data[desta->a_cnt++] = srca->a_data[i];
+	}
+	desta->a_type = srca->a_type;
+}
+
 /*
  * Add value str to array a.  We verify the value str points at is suitable for
  * an insertion into an array of type.

--- a/conf.h
+++ b/conf.h
@@ -35,6 +35,7 @@ extern int 		lineno;
 
 struct bsm_set		*conf_get_bsm_set(char *);
 struct bsm_sequence	*conf_get_parent_sequence(char *);
+void			 conf_merge_bsm_set(struct array *desta, struct bsm_set *src);
 void			 conf_load(char *);
 void			 conf_detail(int, const char *, ...) __attribute__ ((noreturn));
 void			 conf_handle_multiplier(struct bsm_sequence *,

--- a/grammar.y
+++ b/grammar.y
@@ -472,7 +472,20 @@ set_list:
 	;
 
 set_list_ent:
-	STRING
+	SET STRING
+	{
+		struct bsm_set *ptr;
+		assert(set_state != NULL && $2 != NULL);
+
+		if ((ptr = conf_get_bsm_set($2)) == NULL)
+			conf_detail(0, "%s: invalid set", $2);
+		if (set_state->bss_type != ptr->bss_type)
+			conf_detail(0, "%s: type mismatch", $2);
+		conf_merge_bsm_set(&array_state, ptr);
+		free($2);
+		$$ = &array_state;
+	}
+	| STRING
 	{
 		assert(set_state != NULL && $1 != NULL);
 		conf_array_add($1, &array_state, set_state->bss_type);


### PR DESCRIPTION
This extends the current set definition syntax to allow extension of the current set being defined with another set; e.g.

```
define set $base_events <auditevent> {
    AUE_MKDIR;
};

define set $all_events <auditevent> {
    set $base_events,
    AUE_MKDIRAT;
};
```

At the time that `set $base_events` is encountered, all of its events will be immediately merged into the array and end up in $all_events. This may be useful in cases where a basic set of paths/events are wanted, but an extended set for zones may also be defined and used.

Sponsored by: Modirum MDPay, Klara Systems