### PR TITLE
Allow some control over logfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The following organizations and individuals have contributed to the development 
 
 * Aaron L. Meihm
 * Christian S.J. Peron
+* Kyle Evans
 * Mak Kolybabi
 * Marius Halden
 * Seccuris Labs

--- a/bsmtrace.c
+++ b/bsmtrace.c
@@ -191,10 +191,14 @@ main(int argc, char *argv[])
 			/* NOTREACHED */
 		}
 	}
+	/*
+	 * Reading configuration isn't a prerequisite for init'ing the logdir, so do
+	 * this now.  The configuration may try to setup files within the logdir.
+	 */
+	log_init_dir();
 	conf_load(opts.fflag);
 	if (opts.nflag != 0)
 		return (0);
-	log_init_dir();
 	if (!opts.Fflag) {
 		ret = fork();
 		if (ret == -1)

--- a/bsmtrace.conf.5
+++ b/bsmtrace.conf.5
@@ -22,7 +22,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd February 16, 2020
+.Dd February 23, 2020
 .Dt BSMTRACE.CONF 5
 .Os FreeBSD 6.2
 .Sh NAME
@@ -52,6 +52,8 @@ in BNF:
                        "j" | "k" | "l" | "m" | "n" | "o" | "p" | "q" | "r" |
                        "s" | "t" | "u" | "v" | "w" | "x" | "y" | "z"
 <digit> ::= "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9"
+
+<logfile_definition> = "logfile" <string> ";"
 
 <set_definition> ::= "define set" <set_name> <set_type> <set> ";"
 <set_name> ::= "$" <alphanumeric_sequence>
@@ -91,7 +93,6 @@ in BNF:
                "subject" ["not"] ( <set> | (<set_name> | "any")) ";"
                ["timeout" <value> <time_scale> ";"]
 	       ["priority" <value> ";"]
-	       ["log" (<set> | <set_name>) ";"]
 	       ["serial" <value> ";"]
 	       ["scope" <scope> ";"]
 	       ["zone" ( NONE | ANY | <string> ) ";"]

--- a/bsmtrace.conf.5
+++ b/bsmtrace.conf.5
@@ -22,7 +22,7 @@
 .\" LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
-.Dd February 23, 2020
+.Dd April 6, 2020
 .Dt BSMTRACE.CONF 5
 .Os FreeBSD 6.2
 .Sh NAME
@@ -59,7 +59,9 @@ in BNF:
 <set_name> ::= "$" <alphanumeric_sequence>
 <set_type> ::= "<" ("auid" | "euid" | "ruid" | "egid" | "rgid" | "auditevent" |
                "auditclass" | "path" | "logchannel") ">"
-<set> ::= "{" (<subject_set> | <event_set> | <object_set> | <log_set>) ";}"
+<set> ::= "{" <set_spec> ";}"
+<set_spec> ::= "set" <set_name> { "," <set_spec> } |
+				(<subject_set> | <event_set> | <object_set> | <log_set>)
 
 <subject_set> ::= <auid_set> | <euid_set> | <ruid_set> | <egid_set> | <rgid_set>
 <auid_set> ::= <auid> { "," <auid> }

--- a/bsmtrace.h
+++ b/bsmtrace.h
@@ -38,6 +38,7 @@ struct g_conf {
 	int	 Fflag;
 	char	*pflag;
 	char	*lflag;
+	int	 logdirfd;
 	int	 logfd;
 	int	 nflag;
 };

--- a/conf.c
+++ b/conf.c
@@ -57,6 +57,9 @@ int		 lineno = 1;
 static const char		*conffile;
 const char	*yyfile;
 
+/* logfilefd will get set and stashed at each load of a config file. */
+int		logfilefd;
+
 /*
  * Return BSM set named str, or NULL if the set was not found in the BSM set
  * queue.
@@ -99,6 +102,7 @@ conf_load(char *path)
 		bsmtrace_fatal("%s: %s", path, strerror(errno));
 	yyfile = conffile = path;
 	yyin = f;
+	logfilefd = opts.logfd;
 	TAILQ_INIT(&bsm_set_head);
 	yyparse();
 	(void) fclose(f);

--- a/conf.c
+++ b/conf.c
@@ -132,6 +132,33 @@ conf_detail(int ln, const char *fmt, ...)
 	bsmtrace_fatal("%s:%d: %s", yyfile, ln, buf);
 }
 
+void
+conf_merge_bsm_set(struct array *desta, struct bsm_set *src)
+{
+	struct array *srca;
+	size_t i, needed;
+
+	srca = &src->bss_data;
+	needed = desta->a_cnt + srca->a_cnt;
+	if (needed >= desta->a_size) {
+		union array_data *tmp;
+		while (needed >= desta->a_size) {
+			desta->a_size += BSM_ARRAY_MAX;
+		}
+
+		tmp = realloc(desta->a_data, desta->a_size);
+		if (tmp == NULL) {
+			err(1, "Failed to allocate memory");
+		}
+		desta->a_data = tmp;
+	}
+
+	for (i = 0; i < srca->a_cnt; i++) {
+		desta->a_data[desta->a_cnt++] = srca->a_data[i];
+	}
+	desta->a_type = srca->a_type;
+}
+
 /*
  * Add value str to array a.  We verify the value str points at is suitable for
  * an insertion into an array of type.

--- a/conf.h
+++ b/conf.h
@@ -37,6 +37,7 @@ extern int		logfilefd;
 
 struct bsm_set		*conf_get_bsm_set(char *);
 struct bsm_sequence	*conf_get_parent_sequence(char *);
+void			 conf_merge_bsm_set(struct array *desta, struct bsm_set *src);
 void			 conf_load(char *);
 void			 conf_detail(int, const char *, ...) __attribute__ ((noreturn));
 void			 conf_handle_multiplier(struct bsm_sequence *,

--- a/conf.h
+++ b/conf.h
@@ -33,6 +33,7 @@
 extern bsm_set_head_t	bsm_set_head;
 extern int 		lineno;
 extern const char	*yyfile;
+extern int		logfilefd;
 
 struct bsm_set		*conf_get_bsm_set(char *);
 struct bsm_sequence	*conf_get_parent_sequence(char *);

--- a/deuce.h
+++ b/deuce.h
@@ -139,6 +139,7 @@ struct bsm_sequence {
 	int				 bs_seq_time_wnd;
 	int				 bs_seq_time_wnd_prob;
 	char				*bs_zonename;
+	int				 bs_logfile;
 };
 
 /*

--- a/grammar.y
+++ b/grammar.y
@@ -50,7 +50,7 @@ static struct array		 array_state;	/* Volatile array */
 %token	DEFINE SET OBJECT SEQUENCE STATE EVENT TRIGGER
 %token	STATUS MULTIPLIER OBRACE EBRACE SEMICOLON COMMA SUBJECT
 %token	STRING ANY SUCCESS FAILURE INTEGER TIMEOUT NOT HOURS MINUTES DAYS
-%token	PRIORITY WEEKS SECONDS NONE QUOTE OPBRACKET EPBRACKET LOGCHAN
+%token	PRIORITY WEEKS SECONDS NONE QUOTE OPBRACKET EPBRACKET LOGCHAN LOGFILE
 %token	DIRECTORY LOG SCOPE SERIAL TIMEOUTWND TIMEOUTPROB CONFIG INCLUDE ZONE
 %type	<num> status_spec SUCCESS FAILURE INTEGER multiplier_spec timeout_spec
 %type	<num> serial_spec negate_spec priority_spec scope_spec timeout_wnd_spec
@@ -72,6 +72,7 @@ cmd	:
 	| INCLUDE STRING SEMICOLON {
 		include($2);
 	}
+	| logfile_def
 	;
 
 define_def:
@@ -197,6 +198,18 @@ time_spec:
 	| NONE
 	{
 		$$ = 0;
+	}
+	;
+
+logfile_def:
+	LOGFILE STRING SEMICOLON
+	{
+		int fd;
+
+		if ((fd = log_get_logfile($2)) < 0)
+			conf_detail(0, "%s: invalid logfile", $2);
+		logfilefd = fd;
+		free($2);
 	}
 	;
 

--- a/grammar.y
+++ b/grammar.y
@@ -498,7 +498,20 @@ set_list:
 	;
 
 set_list_ent:
-	STRING
+	SET STRING
+	{
+		struct bsm_set *ptr;
+		assert(set_state != NULL && $2 != NULL);
+
+		if ((ptr = conf_get_bsm_set($2)) == NULL)
+			conf_detail(0, "%s: invalid set", $2);
+		if (set_state->bss_type != ptr->bss_type)
+			conf_detail(0, "%s: type mismatch", $2);
+		conf_merge_bsm_set(&array_state, ptr);
+		free($2);
+		$$ = &array_state;
+	}
+	| STRING
 	{
 		assert(set_state != NULL && $1 != NULL);
 		conf_array_add($1, &array_state, set_state->bss_type);

--- a/grammar.y
+++ b/grammar.y
@@ -226,7 +226,11 @@ sequence_def:
 		assert(bs_state == NULL);
 		if ((bs_state = calloc(1, sizeof(*bs_state))) == NULL)
 			bsmtrace_fatal("%s: calloc failed", __func__);
-		/* This will be a parent sequence. */
+		/*
+		 * This will be a parent sequence.  It should use whatever the global
+		 * logfile is set to at definition time.
+		 */
+		bs_state->bs_logfile = logfilefd;
 		bs_state->bs_seq_flags |= BSM_SEQUENCE_PARENT;
 		bs_state->bs_seq_scope = BSM_SCOPE_GLOBAL;
                 bs_state->bs_subj_type = SET_TYPE_NOOP;

--- a/log.c
+++ b/log.c
@@ -181,12 +181,16 @@ log_bsm_txt_file(struct bsm_sequence *bs, struct bsm_record_data *br)
 	ssize_t cc;
 	char *ptr;
 	size_t s;
+	int fd;
 
 	ptr = parse_bsm_generic(bs, br);
 	if (ptr == NULL)
 		return (-1);
 	s = strlen(ptr);
-	cc = write(opts.logfd, ptr, s);
+	fd = opts.logfd;
+	if (bs->bs_logfile >= 0)
+		fd = bs->bs_logfile;
+	cc = write(fd, ptr, s);
 	if (cc == -1) {
 		bsmtrace_fatal("failed to write log data: %s\n",
 		    strerror(errno));

--- a/log.c
+++ b/log.c
@@ -34,9 +34,9 @@
 void
 log_init_dir(void)
 {
-	char logpath[128];
 	struct stat sb;
 
+	opts.logdirfd = -1;
 	if (opts.lflag == NULL)
 		return;
 	if (opts.Bflag != 0 && opts.lflag == NULL) {
@@ -52,14 +52,18 @@ log_init_dir(void)
 	if (access(opts.lflag, W_OK | R_OK | X_OK) != 0) {
 		bsmtrace_fatal("%s: invalid permissions\n", opts.lflag);
 	}
-	(void) sprintf(logpath, "%s/bsmtrace.log", opts.lflag);
-	opts.logfd = open(logpath, O_APPEND | O_WRONLY | O_CREAT, 0644);
+	opts.logdirfd = open(opts.lflag, O_DIRECTORY);
+	if (opts.logdirfd < 0) {
+		bsmtrace_fatal("open: %s failed: %s\n", opts.lflag, strerror(errno));
+	}
+	opts.logfd = openat(opts.logdirfd, "bsmtrace.log",
+	    O_APPEND | O_WRONLY | O_CREAT, 0644);
 	if (opts.logfd == -1) {
-		bsmtrace_fatal("open: %s failed: %s\n", logpath,
+		bsmtrace_fatal("open: %s/bsmtrace.log failed: %s\n", opts.lflag,
 		    strerror(errno));
 	}
-	debug_printf("logging directory and file initialized: %s\n",
-	   logpath);
+	debug_printf("logging directory and file initialized: %s/bsmtrace.log\n",
+	   opts.lflag);
 }
 
 static char *

--- a/log.c
+++ b/log.c
@@ -37,8 +37,12 @@ log_init_dir(void)
 	struct stat sb;
 
 	opts.logdirfd = -1;
-	if (opts.lflag == NULL)
+	opts.logfd = -1;
+	if (opts.lflag == NULL) {
+		/* Default logging fd to stderr if we're not running with -l logdir. */
+		opts.logfd = STDERR_FILENO;
 		return;
+	}
 	if (opts.Bflag != 0 && opts.lflag == NULL) {
 		bsmtrace_fatal("-l directory must be specified for -B\n");
 	}

--- a/log.c
+++ b/log.c
@@ -53,7 +53,7 @@ log_init_dir(void)
 		bsmtrace_fatal("%s: invalid permissions\n", opts.lflag);
 	}
 	(void) sprintf(logpath, "%s/bsmtrace.log", opts.lflag);
-	opts.logfd = open(logpath, O_APPEND | O_WRONLY | O_CREAT);
+	opts.logfd = open(logpath, O_APPEND | O_WRONLY | O_CREAT, 0644);
 	if (opts.logfd == -1) {
 		bsmtrace_fatal("open: %s failed: %s\n", logpath,
 		    strerror(errno));

--- a/log.h
+++ b/log.h
@@ -35,5 +35,6 @@ void 	*log_chan_handler(char *);
 int	 log_bsm_file(struct bsm_sequence *, struct bsm_record_data *);
 void	 log_init_dir(void);
 int	 log_bsm_txt_file(struct bsm_sequence *, struct bsm_record_data *);
+int	 log_get_logfile(const char *filename);
 
 #endif /* LOG_H_ */

--- a/token.l
+++ b/token.l
@@ -39,6 +39,7 @@ struct incl {
 	YY_BUFFER_STATE	incl_buf;
 	const char	*incl_fname;
 	int		 incl_lineno;
+	int		 incl_logfilefd;
 };
 
 static struct incl	*inclp;
@@ -64,6 +65,7 @@ hours		return (HOURS);
 include		return (INCLUDE);
 log		return (LOG);
 log-channel	return (LOGCHAN);
+logfile		return (LOGFILE);
 minutes		return (MINUTES);
 multiplier	return (MULTIPLIER);
 none		return (NONE);
@@ -209,6 +211,8 @@ include(const char *fname)
 	incl->incl_buf = YY_CURRENT_BUFFER;
 	incl->incl_fname = yyfile;
 	incl->incl_lineno = lineno;
+	incl->incl_logfilefd = logfilefd;
+	logfilefd = opts.logfd;
 	inclp = incl;
 	yy_switch_to_buffer(yy_create_buffer(fp, YY_BUF_SIZE));
 	yyfile = fname;
@@ -230,5 +234,6 @@ endinclude(void)
 	yy_switch_to_buffer(incl->incl_buf);
 	yyfile = incl->incl_fname;
 	lineno = incl->incl_lineno;
+	logfilefd = incl->incl_logfilefd;
 	free(incl);
 }


### PR DESCRIPTION
Specific files may now be specified per-sequence; if a logfile is specified but we're in foreground mode, then we'll log to stderr with no distinction from the status quo.

This also fixes an issue where logfiles get created with an arbitrary mode based on stack garbage.

Sponsored by: Modirum MDPay, Klara Systems