### PR TITLE
Fix the build with -fno-common

### DIFF
--- a/bsmtrace.c
+++ b/bsmtrace.c
@@ -30,6 +30,7 @@
 #include "includes.h"
 
 static int	daemonized;	/* daemonized or not? */
+int	audit_pipe_fd;
 
 /*
  * If we are going to be daemonized, write out a pid file to

--- a/bsmtrace.h
+++ b/bsmtrace.h
@@ -43,8 +43,8 @@ struct g_conf {
 	int	 nflag;
 };
 
-struct g_conf opts;
-int	audit_pipe_fd;	/* XXX not happy about this global */
+extern struct g_conf opts;
+extern int	audit_pipe_fd;	/* XXX not happy about this global */
 
 void	bsmtrace_warn(char *, ...);
 void	bsmtrace_fatal(char *, ...) __attribute__ ((noreturn));

--- a/conf.c
+++ b/conf.c
@@ -56,6 +56,7 @@ bsm_set_head_t	 bsm_set_head;
 int		 lineno = 1;
 static const char		*conffile;
 const char	*yyfile;
+struct g_conf opts;
 
 /* logfilefd will get set and stashed at each load of a config file. */
 int		logfilefd;


### PR DESCRIPTION
These two globals were defined in a header, so they "appeared" in multiple
objects. The previous compiler default, -fcommon, would put them into a
common section and merge all of the definitions. In LLVM11 and GCC10, the
default switch to -fno-common and made this an error.

Extern them and plop their definitions in some .c files that seem suitable.