### PR TITLE
Improve error handling in state definition

### DIFF
--- a/bsm.c
+++ b/bsm.c
@@ -32,7 +32,7 @@
 b_head_t s_parent, s_dynamic;
 
 static int
-bsm_match_event(struct bsm_state *bm, struct bsm_record_data *bd)
+bsm_match_event(struct bsm_state *bm, struct bsm_record_data *bd, char *name)
 {
 	struct au_event_ent *aue;
 	int i, match, evdata;
@@ -56,7 +56,7 @@ bsm_match_event(struct bsm_state *bm, struct bsm_record_data *bd)
 		evdata = bd->br_event;
 		break;
 	default:
-		assert(0);
+		bsmtrace_fatal("uknown event type: %d sequence: %s\n", bm->bm_event_type, name);
 	}
 	assert(bm->bm_event_type == SET_TYPE_AUCLASS ||
 	    bm->bm_event_type == SET_TYPE_AUEVENT);
@@ -90,7 +90,7 @@ bsm_match_event(struct bsm_state *bm, struct bsm_record_data *bd)
 		match = (bd->br_status != 0);
 		break;
 	default:
-		assert(0);
+		bsmtrace_fatal("got bad bm->bm_status=%d on sequence %s\n", bm->bm_status, name);
 	}
 	return (match);
 }
@@ -254,7 +254,7 @@ bsm_state_match(struct bsm_sequence *bs, struct bsm_record_data *bd)
 	if (match == 0)
 		return (0);
 	/* Match event. */
-	match = bsm_match_event(bm, bd);
+	match = bsm_match_event(bm, bd, bs->bs_label);
 	if (match == 0)
 		return (0);
 	/* Match object. */
@@ -355,7 +355,7 @@ bsm_check_parent_sequence(struct bsm_sequence *bs, struct bsm_record_data *bd)
 	assert(bs->bs_cur_state == NULL && !TAILQ_EMPTY(&bs->bs_mhead));
 	bm = TAILQ_FIRST(&bs->bs_mhead);
 	/* Match event. */
-	match = bsm_match_event(bm, bd);
+	match = bsm_match_event(bm, bd, bs->bs_label);
 	if (match == 0)
 		return (0);
 	/* Match object. */

--- a/conf.c
+++ b/conf.c
@@ -312,6 +312,7 @@ conf_set_type(char *str)
 int
 conf_validate_state(struct bsm_state *bm)
 {
+
 	if (bm->bm_status == EVENT_NOOP) {
 		bsmtrace_warn(
 		    "status must be one of: failure, success, any\n");

--- a/conf.c
+++ b/conf.c
@@ -309,6 +309,21 @@ conf_set_type(char *str)
 	return (-1);
 }
 
+int
+conf_validate_state(struct bsm_state *bm)
+{
+	if (bm->bm_status == EVENT_NOOP) {
+		bsmtrace_warn(
+		    "status must be one of: failure, success, any\n");
+		return (0);
+	}
+	if (bm->bm_event_type == 0) {
+		bsmtrace_warn("missing audit event specification\n");
+		return (0);
+	}
+	return (1);
+}
+
 void
 conf_handle_multiplier(struct bsm_sequence *bs, struct bsm_state *bm)
 {

--- a/conf.h
+++ b/conf.h
@@ -52,4 +52,6 @@ int			 yywrap(void);
 void			 conf_set_log_channel(struct bsm_set *,
 			     struct bsm_sequence *);
 int			 conf_return_scope(char *);
+int			 conf_validate_state(struct bsm_state *);
+
 #endif	/* BSM_CONF_H_ */

--- a/grammar.y
+++ b/grammar.y
@@ -316,7 +316,7 @@ sequence_options: /* Empty */
 		assert(bs_state != NULL);
 		valid = conf_validate_state($2);
 		if (!valid) {
-			conf_detail(0, "invalid or incomplete state spec");
+			conf_detail(0, "invalid or incomplete state specification");
 		}
 		conf_handle_multiplier(bs_state, $2);
 	}

--- a/grammar.y
+++ b/grammar.y
@@ -311,7 +311,13 @@ sequence_options: /* Empty */
 	}
 	| sequence_options state
 	{
+		int valid;
+
 		assert(bs_state != NULL);
+		valid = conf_validate_state($2);
+		if (!valid) {
+			conf_detail(0, "invalid or incomplete state spec");
+		}
 		conf_handle_multiplier(bs_state, $2);
 	}
 	| sequence_options priority_spec


### PR DESCRIPTION
Currently we will crash if a state is missing a status or event selector (due to assertion failures). Instead of crashing print an error pointing users to the location in the config that needs to be fixed (and what needs to be fixed).

Reported by: @kravietz
BUG: https://github.com/openbsm/bsmtrace/issues/27